### PR TITLE
Fix serialization error for commands containing braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Orphic uses GPT to translate natural language tasks into shell commands, and the
 
 ### Usage
 Orphic is designed to be used like you would use any other CLI tool.
+
 `$ orphic sort ~/Downloads into folders based on media type`
 
 `$ orphic how strong is my network connection`
 
 `$ orphic what version kernel am i running`
+
+`$ orphic show me the name and size of all files larger than 8MB in ~/Downloads/` 
 
 `$ orphic <do task that would otherwise require complex commands that you don't know off the top of your head>`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use serde_json::json;
 use std::error::Error;
 use std::process::Stdio;
 use std::io::{self, Write};
-use std::env::consts::OS;
 
 pub mod prompts;
 
@@ -30,9 +29,8 @@ fn try_extract(body: &String) -> Option<Value> {
         return None;
     }
 
-    let data = body.substring(body.find('{').unwrap(),body.find('}').unwrap()+1); 
-   //     .replace("*", "\\*");
-    //println!("{}", data);
+    let data = body.substring(body.find('{').unwrap(),body.rfind('}').unwrap()+1); 
+    
     match serde_json::from_str(&data) {
         Ok(commands) => Some(commands),
         Err(e) => { println!("{}", e); None }


### PR DESCRIPTION
`try_extract` terminated the command string at the first `}` instead of the last `}`. Switched from `.find` to `.rfind` to fix this.
Also added another README example and fixed some formatting.