### PR TITLE
v0.1.1 - Add safemode as default with option for unsafe execution + GPT-4 flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orphic"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Will Savage <wsavage6316@gmail.com>"]
 description = "A natural language interface for *nix systems.\n(Powered by ChatGPT)"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Orphic is designed to be used like you would use any other CLI tool.
 
 `$ orphic <do task that would otherwise require complex commands that you don't know off the top of your head>`
 
-`-u` or `--unsafe` will execute commands without user verification. 
+`-u` or `--unsafe` will execute commands without user verification.
+
+`-4` or `--gpt4` will attempt to use GPT-4 instead of GPT-3.5-Turbo. Note that this will only work if your OpenAI account has access to the model.
 
 `-i` or `--interpret` will describe the output of the task in natural language (note that this is generally very slow).
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Orphic uses GPT to translate natural language tasks into shell commands, and then executes them on your system. Use at your own risk.
 
 
-* Note: Orphic defaults to safe mode, and will not automatically execute commands without confirmation unless unsafe mode is specified. *
+*Note: Orphic defaults to safe mode, and will not automatically execute commands without confirmation unless unsafe mode is specified.*
 
 ### Installation
 * Make sure your system has rust and cargo.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 ---
 ### Overview
 Orphic uses GPT to translate natural language tasks into shell commands, and then executes them on your system. Use at your own risk.
+
+
+* Note: Orphic defaults to safe mode, and will not automatically execute commands without confirmation unless unsafe mode is specified. *
+
 ### Installation
 * Make sure your system has rust and cargo.
 * `cargo install orphic`
@@ -22,18 +26,20 @@ Orphic is designed to be used like you would use any other CLI tool.
 
 `$ orphic <do task that would otherwise require complex commands that you don't know off the top of your head>`
 
+`-u` or `--unsafe` will execute commands without user verification. 
+
 `-i` or `--interpret` will describe the output of the task in natural language (note that this is generally very slow).
 ```
-$ orphic -i how much disk space is available
+$ orphic -u -i how much disk space is available
 You have 16GB available out of a total of 113GB on your main hard 
 drive, which is mounted on the root directory. 
 Other partitions and file systems are also listed with their 
 respective usage percentages and mount points.
 ```
 
-`-d` or `--debug` will display the raw GPT text along with the regular output.
+`-d` or `--debug` will display the raw GPT text along with the regular output, even in unsafe mode.
 ```
-$ orphic count the lines of rust code in this directory excluding /target/.
+$ orphic -u -d count the lines of rust code in this directory excluding /target/.
 {"command": "find . -name target -prune -o -name '*.rs' -type f -print0 | xargs -0 wc -l"}
 61 ./src/prompts.rs
      219 ./src/main.rs
@@ -42,7 +48,7 @@ $ orphic count the lines of rust code in this directory excluding /target/.
 
 `-r` or `--repl` will start Orphic in a REPL environment.
 ```
-$ orphic -r
+$ orphic -u -r
 orphic> when did i last login
 wtmp begins Sat Mar 18 14:55
 orphic> quit

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,27 @@ use serde_json::json;
 use std::error::Error;
 use std::process::Stdio;
 use std::io::{self, Write};
+use std::fmt;
 
 pub mod prompts;
+
+#[derive(Debug)]
+struct UserAbort();
+
+#[derive(Debug, Copy, Clone)]
+struct Flags {
+    repl:        bool,
+    interpret:   bool,
+    debug:       bool,
+    unsafe_mode: bool
+}
+
+impl fmt::Display for UserAbort {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "User aborted command")
+    }
+}
+impl Error for UserAbort {}
 
 fn get_prompt(key: &'static str) -> &str {
     assert!(prompts::PROMPTS[key].is_string());
@@ -100,7 +119,7 @@ async fn interpret(client: &Client, task: &String, output: &String) -> Result<St
     Ok((response.choices[0]).message.content.to_owned())
 }
 
-async fn try_command(client: &Client, input: String, history: &mut Vec<ChatCompletionRequestMessage>, verbose: bool) -> Result<String, Box<dyn Error>> {
+async fn try_command(client: &Client, input: String, history: &mut Vec<ChatCompletionRequestMessage>, flags: Flags) -> Result<String, Box<dyn Error>> {
     history.push(ChatCompletionRequestMessage {
         role: Role::User,
         content: input + get_prompt("assistant_user"),
@@ -116,12 +135,25 @@ async fn try_command(client: &Client, input: String, history: &mut Vec<ChatCompl
     let response = client.chat().create(request).await?;
     let body = (response.choices[0]).message.content.to_owned();
 
-    if verbose { println!("{}", body); }
+    if flags.debug && flags.unsafe_mode { println!("{}", body); }
 
     return match parse_command(client, &body).await? {
         Some(commands) => {
             match commands["command"].as_str() {
                 Some(command) => {
+                    if !flags.unsafe_mode {
+                        let mut input = String::new();
+                        println!("{}", command);
+                        print!("Execute? [Y/n] ");
+                        io::stdout().flush()?;
+                        io::stdin().read_line(&mut input)?;
+
+                        match input.trim().to_lowercase().as_str() {
+                            ""  | "y" | "yes" => {},
+                            _ => return Err(Box::new(UserAbort()))
+                        };
+                    }
+
                     let mut shell = shell(command);
                     shell.stdout(Stdio::piped());
                     Ok(String::from_utf8(shell.execute_output()?.stdout)?)
@@ -134,7 +166,7 @@ async fn try_command(client: &Client, input: String, history: &mut Vec<ChatCompl
     }
 }
     
-async fn repl(client: &Client, do_interpret: bool, verbose: bool) -> Result<(), Box<dyn Error>> {
+async fn repl(client: &Client, flags: Flags) -> Result<(), Box<dyn Error>> {
     let mut history: Vec<ChatCompletionRequestMessage> = Vec::new();
 
     loop {
@@ -145,18 +177,30 @@ async fn repl(client: &Client, do_interpret: bool, verbose: bool) -> Result<(), 
        match input.as_str().trim() {
             "quit" => break,
             task => {
-                let res = try_command(client, String::from(task), &mut history, verbose).await?;
-                history.push(ChatCompletionRequestMessage {
-                    role: Role::Assistant,
-                    content: res.clone(),
-                    name: None
-                });
-                
-                if do_interpret {
-                    println!("{}", interpret(&client, &(String::from(task.trim())), &res).await?);
-                } else {
-                    println!("{}", res.trim());
+                let res_maybe = try_command(client, String::from(task), &mut history, flags).await;
+                match res_maybe {
+                    Ok(res) => {
+                        history.push(ChatCompletionRequestMessage {
+                            role: Role::Assistant,
+                            content: res.clone(),
+                            name: None
+                        });
+                        
+                        if flags.interpret {
+                            println!("{}", interpret(&client, &(String::from(task.trim())), &res).await?);
+                        } else {
+                            println!("{}", res.trim());
+                        }
+                    },
+                    Err(error) => { 
+                        if error.is::<UserAbort>() {
+                            continue;
+                        } else {
+                            return Err(error);
+                        }
+                    }
                 }
+
             }
         }
     }
@@ -188,12 +232,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .action(ArgAction::SetTrue)
             .help("Display raw GPT output")
         )
+        .arg(
+            Arg::new("unsafe")
+            .short('u')
+            .long("unsafe")
+            .action(ArgAction::SetTrue)
+            .help("Execute commands without confirmation")
+        )
         .get_matches();
+
+    let flags = Flags {
+        repl:        matches.get_flag("repl"),
+        interpret:   matches.get_flag("interpret"),
+        debug:       matches.get_flag("debug"),
+        unsafe_mode: matches.get_flag("unsafe")
+    };
 
     let client = Client::new();
 
-    if matches.get_flag("repl") {
-        repl(&client, matches.get_flag("interpret"), matches.get_flag("debug")).await?;
+    if flags.repl {
+        repl(&client, flags).await?;
         return Ok(());
     }
 
@@ -205,9 +263,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut history: Vec<ChatCompletionRequestMessage> = Vec::new();
 
-    let res = try_command(&client, task.join(" "), &mut history, matches.get_flag("debug")).await?;
+    let res = try_command(&client, task.join(" "), &mut history, flags).await?;
 
-    if matches.get_flag("interpret") {
+    if flags.interpret {
         println!("{}", interpret(&client, &(task.join(" ")), &res).await?);
     } else {
         println!("{}", res.trim());


### PR DESCRIPTION
Orphic will now default to safemode, which shows the user the command to be executed and allows them to choose whether or not to execute. The `-u` flag can be used to bypass this. Also added `--gpt4` flag to allow users with access to GPT-4 to use it over 3.5. 